### PR TITLE
Notion Page API 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+.env
+venv/*
+__pycache__/*
+.idea/*

--- a/crud.py
+++ b/crud.py
@@ -1,0 +1,35 @@
+from db import get_connection
+from models import Page
+
+
+def insert_page(title: str, content: str, parent_id: int | None = None):
+    connection = get_connection()
+    cur = connection.cursor()
+    sql = "insert into page(title, content, parent_id) values(%s, %s, %s)"
+    cur.execute(sql, (title, content, parent_id))
+    connection.commit()
+    connection.close()
+
+
+def select_page(page_id: int) -> Page | None:
+    connection = get_connection()
+    cur = connection.cursor()
+    sql = "select * from page where id=%s"
+    cur.execute(sql, page_id)
+    result = cur.fetchone()
+    connection.close()
+    if not result:
+        return None
+    return Page(*result)
+
+
+def select_pages_by_parent_id(parent_page_id: int) -> list[Page]:
+    connection = get_connection()
+    cur = connection.cursor()
+    sql = "select * from page where parent_id=%s"
+    cur.execute(sql, parent_page_id)
+    results = cur.fetchall()
+    connection.close()
+    if not results:
+        return []
+    return [Page(*res) for res in results]

--- a/db.py
+++ b/db.py
@@ -1,0 +1,15 @@
+import pymysql
+from pymysql import Connection
+
+from env import HOST, PORT, USER, PASSWORD, DB
+
+
+def get_connection() -> Connection:
+    return pymysql.connect(
+        host=HOST,
+        port=PORT,
+        user=USER,
+        password=PASSWORD,
+        db=DB,
+        charset="utf8",
+    )

--- a/env.py
+++ b/env.py
@@ -1,0 +1,11 @@
+from os import getenv
+
+from dotenv import load_dotenv
+
+load_dotenv(verbose=True)
+
+DB = getenv("DB_NAME")
+USER = getenv("DB_USER")
+PASSWORD = getenv("DB_PASSWORD")
+HOST = getenv("DB_HOST")
+PORT = int(getenv("DB_PORT"))

--- a/main.py
+++ b/main.py
@@ -1,0 +1,25 @@
+from pprint import pprint
+
+
+from schemas import PageResponseSchema
+from services import get_sub_pages, get_breadcrumbs, get_page
+from settings import initialize_dummy_data
+
+initialize_dummy_data()
+
+while True:
+    page_id = int(input("페이지 ID: "))
+    page = get_page(page_id)
+    if not page:
+        print("Error 404")
+        break
+
+    pprint(
+        PageResponseSchema(
+            page.id,
+            page.title,
+            page.content,
+            get_sub_pages(page_id),
+            get_breadcrumbs(page_id),
+        ).to_dict()
+    )

--- a/models.py
+++ b/models.py
@@ -1,0 +1,6 @@
+class Page:
+    def __init__(self, id: int, title: str, content: str, parent_id: int | None = None):
+        self.id = id
+        self.title = title
+        self.content = content
+        self.parent_id = parent_id

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+cffi==1.15.1
+cryptography==41.0.3
+pycparser==2.21
+PyMySQL==1.1.0
+python-dotenv==1.0.0

--- a/schemas.py
+++ b/schemas.py
@@ -1,0 +1,35 @@
+class PageSchema:
+    def __init__(self, id: int, title: str, content: str, parent_id: int | None = None):
+        self.id = id
+        self.title = title
+        self.content = content
+        self.parent_id = parent_id
+
+
+class PageSummarySchema:
+    def __init__(self, id: int, title: str):
+        self.id = id
+        self.title = title
+
+
+class PageResponseSchema:
+    def __init__(
+        self,
+        id: int,
+        title: str,
+        content: str,
+        sub_pages: list[PageSummarySchema],
+        breadcrumbs: list[PageSummarySchema],
+    ):
+        self.id = id
+        self.title = title
+        self.content = content
+        self.sub_pages = sub_pages
+        self.breadcrumbs = breadcrumbs
+
+    def to_dict(self):
+        dic = self.__dict__
+        dic["sub_pages"] = [sub_page.__dict__ for sub_page in self.sub_pages]
+        dic["breadcrumbs"] = [breadcrumb.__dict__ for breadcrumb in self.breadcrumbs]
+
+        return dic

--- a/services.py
+++ b/services.py
@@ -1,0 +1,34 @@
+from collections import deque
+from typing import Deque
+
+from crud import select_pages_by_parent_id, select_page
+from schemas import PageSummarySchema, PageSchema
+
+
+def get_page(page_id: int) -> PageSchema | None:
+    page = select_page(page_id)
+    if not page:
+        return None
+    return PageSchema(page.id, page.title, page.content, page.parent_id)
+
+
+def get_sub_pages(page_id: int) -> list[PageSummarySchema]:
+    return [
+        PageSummarySchema(sub_page.id, sub_page.title)
+        for sub_page in select_pages_by_parent_id(page_id)
+    ]
+
+
+def get_breadcrumbs(page_id: int) -> list[PageSummarySchema]:
+    page = select_page(page_id)
+    if not page:
+        return []
+
+    breadcrumbs: Deque[PageSummarySchema] = deque(
+        [PageSummarySchema(page.id, page.title)]
+    )
+    while page and page.parent_id:
+        page = select_page(page.parent_id)
+        breadcrumbs.appendleft(PageSummarySchema(page.id, page.title))
+
+    return list(breadcrumbs)

--- a/settings.py
+++ b/settings.py
@@ -9,7 +9,7 @@ def create_table() -> None:
         CREATE TABLE page(\
         id int NOT NULL AUTO_INCREMENT PRIMARY KEY,\
         title varchar(256) NOT NULL,\
-        content varchar(256) NOT NULL,\
+        content text NOT NULL,\
         parent_id int,\
         FOREIGN KEY (parent_id) REFERENCES page(id)\
         );"

--- a/settings.py
+++ b/settings.py
@@ -1,0 +1,45 @@
+from crud import insert_page
+from db import get_connection
+
+
+def create_table() -> None:
+    connection = get_connection()
+    cur = connection.cursor()
+    sql = f"\
+        CREATE TABLE page(\
+        id int NOT NULL AUTO_INCREMENT PRIMARY KEY,\
+        title varchar(256) NOT NULL,\
+        content varchar(256) NOT NULL,\
+        parent_id int,\
+        FOREIGN KEY (parent_id) REFERENCES page(id)\
+        );"
+    cur.execute(sql)
+    connection.commit()
+    connection.close()
+
+
+def drop_table() -> None:
+    connection = get_connection()
+    cur = connection.cursor()
+    sql = "SHOW TABLES LIKE 'page';"
+    cur.execute(sql)
+    if cur.fetchone():
+        sql = 'DROP TABLE page;'
+        cur.execute(sql)
+    connection.commit()
+    connection.close()
+
+
+def initialize_dummy_data() -> None:
+    drop_table()
+    create_table()
+    insert_page("page 1", "content")
+    insert_page("page 2", "content", 1)
+    insert_page("page 3", "content", 1)
+    insert_page("page 4", "content", 2)
+    insert_page("page 5", "content", 3)
+    insert_page("page 6", "content", 1)
+    insert_page("page 7", "content")
+    insert_page("page 8", "content", 3)
+    insert_page("page 9", "content", 4)
+    insert_page("page 10", "content", 9)


### PR DESCRIPTION
## 작업내용

### Notion Page API 구현
- 더미 데이터 세팅
- 기본 페이지 조회
  - 브레드크럼스 추가
  - 하위 페이지 추가

### ERD
<img width="233" alt="image" src="https://github.com/want-free-python/notion-api/assets/68409255/c769597d-f27d-4063-988b-69062d086dfc">

### 하위 페이지 추가방법
하위 페이지 추가하는 방법은 parent_id를 기준으로 SELECT 검색으로 추가하였습니다.

### 브레드크럼스 추가방법
페이지를 기준으로 상위 부모 페이지를 찾아가는 쿼리를 상위 페이지가 없을 때까지 확인합니다.

### 요청/응답구조

- 요청: page_id - integer
- 응답 타입
```
{
  'breadcrumbs': [{'id': integer, 'title': string}],
  'content': string,
  'id': integer,
  'sub_pages': [{'id': integer, 'title': string}],
  'title': string
}
```
- 응답 예시
```
{
  'breadcrumbs': [{'id': 7, 'title': 'page 7'}],
  'content': 'content',
  'id': 7,
  'sub_pages': [{'id': 1, 'title': 'page 1'}],
  'title': 'page 7'
}
```

## 참고사항

- python 3.11 ^
- .env 파일을 추가해야 동작합니다.
  - .env 파일은 디스코드에 공유하겠습니다.


